### PR TITLE
Roger/fine tuning fewshot

### DIFF
--- a/configs/voc2012_semantic/README.md
+++ b/configs/voc2012_semantic/README.md
@@ -1,0 +1,4 @@
+# VOC2012
+
+- voc2012_vgg16_no_bn_fcn32s_COS_head.yaml: 0.55 mIoU
+- voc2012_vgg16_no_bn_fcn32s_head.yaml: 0.57 mIoU

--- a/configs/voc2012_semantic/voc2012_vgg16_no_bn_fcn32s_COS_head.yaml
+++ b/configs/voc2012_semantic/voc2012_vgg16_no_bn_fcn32s_COS_head.yaml
@@ -1,0 +1,54 @@
+name: 'voc2012_semantic_segmentation_vgg16_no_bn'
+task: 'semantic_segmentation'
+input_dim: (3, 224, 224)
+num_classes: 21 # (20 annotated class + 1 background)
+save_model: True
+
+SYSTEM:
+  use_cpu: False
+  num_workers: 16
+
+BACKBONE:
+  network: 'vgg16_seg'
+  pooling: False
+  use_pretrained: True
+  pretrained_path: "/data/pretrained_model/vgg16-397923af.pth"
+
+CLASSIFIER:
+  classifier: "fcn32s_cos"
+
+LOSS:
+  loss: 'semantic_nllloss'
+
+DATASET:
+  dataset: 'VOC2012_seg'
+  TRANSFORM:
+    TRAIN:
+      transforms: ('normalize', )
+      TRANSFORMS_DETAILS:
+        NORMALIZE:
+          mean: (0.4700, 0.4468, 0.4076)
+          sd: (0.2439, 0.2390, 0.2420)
+    TEST:
+      transforms: ('normalize', )
+      TRANSFORMS_DETAILS:
+        NORMALIZE:
+          mean: (0.4700, 0.4468, 0.4076)
+          sd: (0.2439, 0.2390, 0.2420)
+
+TRAIN:
+  max_epochs: 50
+  batch_size: 1
+  initial_lr: 1e-4
+  lr_scheduler: "step_down"
+  step_down_gamma: 0.5
+  step_down_on_epoch: [15, 18, 21, 24, 27, 30]
+  log_interval: 500
+  OPTIMIZER:
+    type: "SGD"
+    momentum: 0.9
+    weight_decay: 1e-5
+
+
+TEST:
+  batch_size: 1

--- a/configs/voc2012_semantic/voc2012_vgg16_no_bn_fcn32s_COS_head.yaml
+++ b/configs/voc2012_semantic/voc2012_vgg16_no_bn_fcn32s_COS_head.yaml
@@ -1,4 +1,4 @@
-name: 'voc2012_semantic_segmentation_vgg16_no_bn'
+name: 'voc2012_semantic_segmentation_vgg16_no_bn_COS_HEAD'
 task: 'semantic_segmentation'
 input_dim: (3, 224, 224)
 num_classes: 21 # (20 annotated class + 1 background)
@@ -16,6 +16,12 @@ BACKBONE:
 
 CLASSIFIER:
   classifier: "fcn32s_cos"
+  SEGHEAD:
+    use_bilinear_interpolation: True
+    COSINE:
+      weight_norm: False
+      train_scale_factor: 50
+      val_scale_factor: 3
 
 LOSS:
   loss: 'semantic_nllloss'

--- a/modules/classifier/dispatcher.py
+++ b/modules/classifier/dispatcher.py
@@ -21,6 +21,10 @@ def dispatcher(cfg, feature_shape):
         import classifier.fcn as fcn
         fcn32s_head = fcn.fcn32s(cfg, feature_shape)
         return fcn32s_head
+    elif classifier_name == "fcn32s_cos":
+        import classifier.fcn_cos as fcn_cos
+        fcn32s_cos_head = fcn_cos.fcn32s_cos(cfg, feature_shape)
+        return fcn32s_cos_head
     elif classifier_name == "identity":
         identity_module = identity_mod()
         return identity_module

--- a/modules/classifier/fcn.py
+++ b/modules/classifier/fcn.py
@@ -7,7 +7,7 @@ class fcn32s(nn.Module):
     def __init__(self, cfg, feature_shape):
         super().__init__()
         self.num_classes = cfg.num_classes
-        self.use_bilinear_interpolation = True # TODO: read from cfg
+        self.use_bilinear_interpolation = cfg.CLASSIFIER.SEGHEAD.use_bilinear_interpolation
         # fc6
         self.fc6 = nn.Conv2d(512, 4096, 7)
         self.relu6 = nn.ReLU(inplace=True)

--- a/modules/classifier/fcn_cos.py
+++ b/modules/classifier/fcn_cos.py
@@ -1,0 +1,66 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.autograd import Variable
+from torch.nn.utils.weight_norm import WeightNorm
+
+class pixel_classifier(nn.Module):
+    def __init__(self, cfg, feature_shape, in_channel, weight_norm = False):
+        super().__init__()
+        self.num_classes = cfg.num_classes
+        self.class_mat = nn.Conv2d(in_channel, self.num_classes, 1, bias = False)
+        self.weight_norm = weight_norm
+        if weight_norm:
+            # conv weight shape: (num_classes, in_channel, 1, 1)
+            WeightNorm.apply(self.class_mat, 'weight', dim=0)
+        self.scale_factor = 50
+    
+    def forward(self, x):
+        '''
+        x: (B, in_channel, H, W)
+        '''
+        # x_norm: (B, in_channel, H, W) where x_norm[i, :, H, W] is the norm of
+        # x[i, :, H, W]. That is, x/x_norm yields normalized value along channel axis
+        x_norm = torch.norm(x, p=2, dim=1).unsqueeze(1).expand_as(x)
+        x_normalized = x.div(x_norm + 1e-5) # avoid div by zero
+        if not self.weight_norm:
+            class_mat_norm = torch.norm(self.class_mat.weight.data, p=2, dim=1).unsqueeze(1).expand_as(self.class_mat.weight.data)
+            self.class_mat.weight.data = self.class_mat.weight.data.div(class_mat_norm + 1e-5)
+        cos_dist = self.class_mat(x_normalized)
+        scores = self.scale_factor * (cos_dist) 
+
+        return scores
+
+class fcn32s_cos(nn.Module):
+
+    def __init__(self, cfg, feature_shape):
+        super().__init__()
+        self.num_classes = cfg.num_classes
+        # fc6
+        self.fc6 = nn.Conv2d(512, 4096, 7)
+        self.relu6 = nn.ReLU(inplace=True)
+        self.drop6 = nn.Dropout2d()
+
+        # fc7
+        self.fc7 = nn.Conv2d(4096, 4096, 1)
+        self.relu7 = nn.ReLU(inplace=True)
+        self.drop7 = nn.Dropout2d()
+
+        self.pixel_classifier = pixel_classifier(cfg, feature_shape, 4096)
+
+    def forward(self, x, size_ = None):
+        x = self.relu6(self.fc6(x))
+        x = self.drop6(x)
+
+        x = self.relu7(self.fc7(x))
+        x = self.drop7(x)
+
+        x = self.pixel_classifier(x)
+
+        # Origianl FCN paper uses transpose Conv to upscale the image
+        # However, experiments showed that it doesn't work well with cosine similarity.
+        # ... So we changed it to bilinear interpolation
+
+        x = F.interpolate(x, size = size_, mode = 'bilinear', align_corners=False)
+
+        return x

--- a/modules/config_guard/default.py
+++ b/modules/config_guard/default.py
@@ -46,8 +46,12 @@ _C.CLASSIFIER.factor = 0
 _C.CLASSIFIER.FC = CN()
 _C.CLASSIFIER.FC.hidden_layers = (1024,)
 _C.CLASSIFIER.FC.bias = False
-_C.CLASSIFIER.C1 = CN()
-_C.CLASSIFIER.C1.use_softmax = False
+_C.CLASSIFIER.SEGHEAD = CN()
+_C.CLASSIFIER.SEGHEAD.use_bilinear_interpolation = True
+_C.CLASSIFIER.SEGHEAD.COSINE = CN()
+_C.CLASSIFIER.SEGHEAD.COSINE.weight_norm = False
+_C.CLASSIFIER.SEGHEAD.COSINE.train_scale_factor = 50
+_C.CLASSIFIER.SEGHEAD.COSINE.val_scale_factor = 3
 
 #######################
 # Network (ignore backbone & classification)

--- a/modules/loss/loss.py
+++ b/modules/loss/loss.py
@@ -18,19 +18,14 @@ class cross_entropy(nn.Module):
 class semantic_segmentation_nllloss(nn.Module):
     def __init__(self, cfg):
         super().__init__()
-        self.use_softmax = cfg.CLASSIFIER.C1.use_softmax
-        self.crit = nn.NLLLoss(ignore_index=-1)
+        self.crit = nn.CrossEntropyLoss()
     
     def forward(self, output, label):
         assert output.shape[-2:] == label.shape[-2:],\
             "output: {}; label: {}".format(output.shape[-2:], label.shape[-2:])
-        if self.use_softmax:
-            raise NotImplementedError
-        else:
-            loss = F.log_softmax(output, dim=1)
-            label = label.long()
-            loss = self.crit(loss, label)
-            return loss
+        label = label.long()
+        loss = self.crit(output, label)
+        return loss
 
 class naive_VAE(nn.Module):
     def __init__(self, cfg):

--- a/modules/utils/semantic_metric.py
+++ b/modules/utils/semantic_metric.py
@@ -10,7 +10,7 @@ def compute_pixel_acc(pred, label, fg_only=True):
     '''
     assert pred.shape == label.shape
     if fg_only:
-        valid = (label >= 0)
+        valid = (label > 0)
         acc_sum = (valid * (pred == label)).sum()
         valid_sum = valid.sum()
         acc = float(acc_sum) / (valid_sum + 1e-10)


### PR DESCRIPTION
- Replace usualy 1x1 conv (FC across channel) to cosine similarity between pixel feature/class weight and obtained reasonable mIoU (only ~0.02 worse than standard 1x1 conv in conventional task)
- Fix a minor issue in fg_only semantic segmentation pixel-wise accuracy computation